### PR TITLE
Fix typo on Telegram Node (no-changelog)

### DIFF
--- a/packages/nodes-base/nodes/Telegram/Telegram.node.ts
+++ b/packages/nodes-base/nodes/Telegram/Telegram.node.ts
@@ -227,7 +227,7 @@ export class Telegram implements INodeType {
 						name: 'Edit Message Text',
 						value: 'editMessageText',
 						description: 'Edit a text message',
-						action: 'Edit a test message',
+						action: 'Edit a text message',
 					},
 					{
 						name: 'Pin Chat Message',


### PR DESCRIPTION
fix: typo on telegram edit text message action.

## Summary

Fix a typo on Telegram Node (edit text message)